### PR TITLE
Allow variables within field declarations

### DIFF
--- a/gpt_json/prompts.py
+++ b/gpt_json/prompts.py
@@ -27,7 +27,9 @@ def generate_schema_prompt(schema: BaseModel | list[BaseModel]) -> str:
                 payload.append(f'"{key}": {value.type_.__name__.lower()}')
             if value.field_info.description:
                 payload[-1] += f' // {value.field_info.description}'
-        return '{' + ', '.join(payload) + '}'
+        # All brackets are double defined so they will passthrough a call to `.format()` where we
+        # pass custom variables
+        return '{{\n' + ',\n'.join(payload) + '\n}}'
 
     origin = get_origin(schema)
     args = get_args(schema)

--- a/gpt_json/tests/test_prompts.py
+++ b/gpt_json/tests/test_prompts.py
@@ -15,30 +15,30 @@ def strip_whitespace(input_string: str):
         (
             MySchema,
             """
-            {
+            {{
                 "text": str,
                 "items": str[],
                 "numerical": int | float,
-                "sub_element": {
+                "sub_element": {{
                     "name": str
-                },
+                }},
                 "reason": bool // Explanation
-            }
+            }}
             """
         ),
         (
             list[MySchema],
             """
             [
-            {
+            {{
             "text": str,
             "items": str[],
             "numerical": int | float,
-            "sub_element": {
+            "sub_element": {{
                 "name": str
-            },
+            }},
             "reason": bool // Explanation
-            }, // Repeat for as many objects as are relevant
+            }}, // Repeat for as many objects as are relevant
             ]
             """
         )


### PR DESCRIPTION
Allow user-defined variables to be specified in the `description` field. These variables will be inserted into the prompt via regular string formatting when requests are sent to the server.