### PR TITLE
[bugfix] two or more gptjsons -- schema collision 

### DIFF
--- a/gpt_json/gpt.py
+++ b/gpt_json/gpt.py
@@ -1,7 +1,8 @@
+import logging
 from dataclasses import replace
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
-from typing import Generic, List, Type, TypeVar, get_origin, get_args
+from typing import Any, Generic, List, Type, TypeVar, get_args, get_origin
 
 import backoff
 import openai
@@ -9,14 +10,12 @@ from openai.error import APIConnectionError, RateLimitError
 from openai.error import Timeout as OpenAITimeout
 from pydantic import BaseModel
 from tiktoken import encoding_for_model
-from typing import Any
 
-from gpt_json.models import GPTMessage, GPTModelVersion, ResponseType, FixTransforms
+from gpt_json.models import (FixTransforms, GPTMessage, GPTModelVersion,
+                             ResponseType)
 from gpt_json.parsers import find_json_response
-from gpt_json.transformations import fix_truncated_json, fix_bools
 from gpt_json.prompts import generate_schema_prompt
-
-import logging
+from gpt_json.transformations import fix_bools, fix_truncated_json
 
 logger = logging.getLogger('my_logger')
 handler = logging.StreamHandler()
@@ -41,6 +40,7 @@ class GPTJSON(Generic[SchemaType]):
     A wrapper over GPT that provides basic JSON parsing and response handling.
 
     """
+    _cls_schema_model: Type[SchemaType] = None
     schema_model: Type[SchemaType] = None
 
     def __init__(
@@ -73,6 +73,8 @@ class GPTJSON(Generic[SchemaType]):
         self.timeout = timeout
         self.openai_max_retries = openai_max_retries
         self.openai_arguments = kwargs
+        self.schema_model = self._cls_schema_model
+        GPTJSON._cls_schema_model = None
 
         if not self.schema_model:
             raise ValueError("GPTJSON needs to be instantiated with a schema model, like GPTJSON[MySchema](...args).")
@@ -296,5 +298,5 @@ class GPTJSON(Generic[SchemaType]):
 
     def __class_getitem__(cls, item):
         new_cls = super().__class_getitem__(item)
-        new_cls.schema_model = item
+        new_cls._cls_schema_model = item
         return new_cls

--- a/gpt_json/tests/test_gpt.py
+++ b/gpt_json/tests/test_gpt.py
@@ -2,11 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import openai
 import pytest
+from pydantic import BaseModel, Field
 
 from gpt_json.gpt import GPTJSON
-from gpt_json.models import GPTMessage, GPTMessageRole, FixTransforms, GPTModelVersion
+from gpt_json.models import (FixTransforms, GPTMessage, GPTMessageRole,
+                             GPTModelVersion)
 from gpt_json.tests.shared import MySchema, MySubSchema
-from pydantic import BaseModel, Field
 
 
 def test_throws_error_if_no_model_specified():
@@ -215,6 +216,24 @@ def test_trim_messages(input_messages, expected_output_messages):
     for output_message, expected_output_message in zip(output_messages, expected_output_messages):
         assert output_message.role == expected_output_message.role
         assert output_message.content == expected_output_message.content
+
+def test_two_gptjsons():
+    class TestSchema1(BaseModel):
+        field1: str
+    class TestSchema2(BaseModel):
+        field2: str
+    
+    gptjson1 = GPTJSON[TestSchema1](None)
+
+    # shouldn't allow instantion without a schema
+    with pytest.raises(ValueError):
+        gptjson2 = GPTJSON(None)
+    
+    gptjson2 = GPTJSON[TestSchema2](None)
+
+    assert gptjson1.schema_model == TestSchema1
+    assert gptjson2.schema_model == TestSchema2
+
 
 
 def test_fill_message_template():


### PR DESCRIPTION
schema collision when you instantiate multiple gptjsons, see testcase:

```python
gptjson1 = GPTJSON[TestSchema1](None)

# shouldn't allow instantion without a schema
with pytest.raises(ValueError):
    gptjson2 = GPTJSON(None)

gptjson2 = GPTJSON[TestSchema2](None)

assert gptjson1.schema_model == TestSchema1
assert gptjson2.schema_model == TestSchema2
```