### PR TITLE
Use StrEnum for >=3.11

### DIFF
--- a/gpt_json/models.py
+++ b/gpt_json/models.py
@@ -1,22 +1,28 @@
 from dataclasses import dataclass
 from enum import Enum, unique
+import sys
 
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+    EnumSuper = (StrEnum,)
+else:
+    EnumSuper = (str, Enum)
 
 @unique
-class ResponseType(str, Enum):
+class ResponseType(*EnumSuper):
     DICTIONARY = "DICTIONARY"
     LIST = "LIST"
 
 
 @unique
-class GPTMessageRole(str, Enum):
+class GPTMessageRole(*EnumSuper):
     SYSTEM = "system"
     USER = "user"
     ASSISTANT = "assistant"
 
 
 @unique
-class GPTModelVersion(str, Enum):
+class GPTModelVersion(*EnumSuper):
     GPT_3_5 = "gpt-3.5-turbo"
     GPT_4 = "gpt-4-0314"
 


### PR DESCRIPTION
A [previous PR](https://github.com/piercefreeman/gpt-json/pull/11) added support for json serializable enum values by combining a str superclass with Enum. 3.11 introduces a formal class to support this case, which is used by some third party libraries that have special handling for serialization / deserialization. If the client is on 3.11, this PR will switch the definitions at runtime.