### PR TITLE
Local request timeout support

### DIFF
--- a/examples/stream_example.py
+++ b/examples/stream_example.py
@@ -24,11 +24,14 @@ Respond with the following JSON schema:
 {json_schema}
 """
 
+
 class TutorSchema(BaseModel):
     student_model: str
     tutor_response: str
 
+
 gpt_json = GPTJSON[TutorSchema](API_KEY, model=GPTModelVersion.GPT_4)
+
 
 async def main():
     problem = "x^2 + 3 = 12"
@@ -47,26 +50,33 @@ async def main():
     ]
 
     print("\nTeacher's thought process:")
-    teacher_generator = gpt_json.stream(messages=messages, format_variables={"student_model_key": "student_model", "problem" : problem}) 
+    teacher_generator = gpt_json.stream(
+        messages=messages,
+        format_variables={"student_model_key": "student_model", "problem": problem},
+    )
     seen_keys = set()
     async for partial_teacher in teacher_generator:
         if partial_teacher.event == StreamEventEnum.OBJECT_CREATED:
             continue
 
         # print a heading when we see a new key
-        if partial_teacher.event == StreamEventEnum.KEY_UPDATED and partial_teacher.updated_key not in seen_keys:
+        if (
+            partial_teacher.event == StreamEventEnum.KEY_UPDATED
+            and partial_teacher.updated_key not in seen_keys
+        ):
             if partial_teacher.updated_key == "student_model":
                 print("Thought: ", end="")
             elif partial_teacher.updated_key == "tutor_response":
                 print("Response to student: ", end="")
             seen_keys.add(partial_teacher.updated_key)
-        
+
         print(partial_teacher.value_change, end="")
- 
+
         # print a newline when we see a key has been completed
         if partial_teacher.event == StreamEventEnum.KEY_COMPLETED:
             print()
         sys.stdout.flush()
-    
+
+
 if __name__ == "__main__":
     asyncio.run(main())

--- a/gpt_json/gpt.py
+++ b/gpt_json/gpt.py
@@ -1,5 +1,5 @@
 import logging
-from asyncio import wait_for
+from asyncio import wait_for, TimeoutError as AsyncTimeoutError
 from dataclasses import replace
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
@@ -328,7 +328,10 @@ class GPTJSON(Generic[SchemaType]):
         if self.timeout is None:
             return await execute_prediction
         else:
-            return await wait_for(execute_prediction, timeout=self.timeout)
+            try:
+                return await wait_for(execute_prediction, timeout=self.timeout)
+            except AsyncTimeoutError:
+                raise OpenAITimeout
 
     def fill_message_template(
         self, message: GPTMessage, format_variables: dict[str, Any]

--- a/gpt_json/gpt.py
+++ b/gpt_json/gpt.py
@@ -1,4 +1,5 @@
 import logging
+from asyncio import wait_for
 from dataclasses import replace
 from json import loads as json_loads
 from json.decoder import JSONDecodeError
@@ -68,7 +69,7 @@ class GPTJSON(Generic[SchemaType]):
         auto_trim_response_overhead: int = 0,
         # For messages that are relatively deterministic
         temperature=0.2,
-        timeout=60,
+        timeout: int | None = None,
         openai_max_retries=3,
         **kwargs,
     ):
@@ -79,7 +80,7 @@ class GPTJSON(Generic[SchemaType]):
         :param auto_trim_response_overhead: If auto_trim is True, will leave at least `auto_trim_response_overhead` space
             for the output payload. For GPT, initial prompt + response <= allowed tokens.
         :param temperature: Temperature (or variation) of response payload; 0 is the most deterministic, 1 is the most random
-        :param timeout: Timeout in seconds for each OpenAI API calls
+        :param timeout: Timeout in seconds for each OpenAI API calls before timing out.
         :param openai_max_retries: Amount of times to retry failed API calls, caused by often transient load or rate limit issues
         :param kwargs: Additional arguments to pass to OpenAI's `openai.Completion.create` method
 
@@ -294,6 +295,10 @@ class GPTJSON(Generic[SchemaType]):
         max_response_tokens: int | None,
         stream: bool = False,
     ):
+        """
+        If a request times out, will raise an OpenAITimeout.
+
+        """
         logger.debug("------- START MESSAGE ----------")
         logger.debug(messages)
         logger.debug("------- END MESSAGE ----------")
@@ -305,16 +310,25 @@ class GPTJSON(Generic[SchemaType]):
         if max_response_tokens:
             optional_parameters["max_tokens"] = max_response_tokens
 
-        return await openai.ChatCompletion.acreate(
+        execute_prediction = openai.ChatCompletion.acreate(
             model=self.model,
             messages=[self.message_to_dict(message) for message in messages],
             temperature=self.temperature,
-            timeout=self.timeout,
             api_key=self.api_key,
             stream=stream,
             **optional_parameters,
             **self.openai_arguments,
         )
+
+        # The 'timeout' parameter supported by the OpenAI API is only used to cycle
+        # the model while it's warming up
+        # https://github.com/openai/openai-python/blob/fe3abd16b582ae784d8a73fd249bcdfebd5752c9/openai/api_resources/chat_completion.py#L41
+        # We instead use a client-side timeout to prevent the API from hanging, which is more inline
+        # with the expected behavior of our passed timeout.
+        if self.timeout is None:
+            return await execute_prediction
+        else:
+            return await wait_for(execute_prediction, timeout=self.timeout)
 
     def fill_message_template(
         self, message: GPTMessage, format_variables: dict[str, Any]

--- a/gpt_json/parsers.py
+++ b/gpt_json/parsers.py
@@ -1,9 +1,7 @@
-import json
 from re import DOTALL, finditer
 
 from gpt_json.models import ResponseType
-from gpt_json.streaming import StreamEventEnum
-from gpt_json.transformations import JsonFixEnum, fix_truncated_json, is_truncated
+from gpt_json.transformations import is_truncated
 
 
 def find_json_response(full_response, extract_type):

--- a/gpt_json/tests/test_gpt.py
+++ b/gpt_json/tests/test_gpt.py
@@ -1,4 +1,7 @@
-from unittest.mock import patch
+import asyncio
+from json import dumps as json_dumps
+from time import time
+from unittest.mock import AsyncMock, patch
 
 import openai
 import pytest
@@ -172,7 +175,6 @@ async def test_acreate(
                 for message in messages
             ],
             temperature=0.0,
-            timeout=60,
             api_key=None,
             stream=False,
         )
@@ -311,3 +313,56 @@ async def test_unable_to_find_valid_json_payload():
 async def test_unknown_model_to_infer_max_tokens():
     with pytest.raises(ValueError):
         GPTJSON[MySchema](model="UnknownModel", auto_trim=True)
+
+
+@pytest.mark.asyncio
+async def test_timeout():
+    class MockResponse:
+        """
+        We need to build an actual response class here because the internal openai
+        code postprocesses with the aiohttp response.
+
+        """
+
+        def __init__(self, response_text: str):
+            self.status = 200
+            self.headers: dict[str, str] = {}
+            self.response_text = response_text
+
+        async def read(self):
+            mock_response = {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": self.response_text,
+                        },
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+            return json_dumps(mock_response).encode()
+
+    with patch("aiohttp.ClientSession.request", new_callable=AsyncMock) as mock_request:
+        # Mock a stalling request
+        async def side_effect(*args, **kwargs):
+            await asyncio.sleep(4)
+            return MockResponse("TEST_RESPONSE")
+
+        mock_request.side_effect = side_effect
+
+        gpt = GPTJSON[MySchema](api_key="ABC", timeout=2)
+
+        start_time = time()
+
+        with pytest.raises(TimeoutError):
+            await gpt.run(
+                [GPTMessage(GPTMessageRole.SYSTEM, "message content")],
+            )
+
+        end_time = time()
+        duration = end_time - start_time
+
+        # Assert duration is about 2 seconds
+        pytest.approx(duration, 2, 0.2)

--- a/gpt_json/tests/test_gpt.py
+++ b/gpt_json/tests/test_gpt.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import openai
 import pytest
 from pydantic import BaseModel, Field
+from openai.error import Timeout as OpenAITimeout
 
 from gpt_json.gpt import GPTJSON
 from gpt_json.models import FixTransforms, GPTMessage, GPTMessageRole, GPTModelVersion
@@ -356,7 +357,7 @@ async def test_timeout():
 
         start_time = time()
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(OpenAITimeout):
             await gpt.run(
                 [GPTMessage(GPTMessageRole.SYSTEM, "message content")],
             )

--- a/gpt_json/tests/test_streaming.py
+++ b/gpt_json/tests/test_streaming.py
@@ -147,7 +147,6 @@ async def test_gpt_stream(
                 for message in messages
             ],
             temperature=0.0,
-            timeout=60,
             stream=True,
             api_key=None,
         )

--- a/gpt_json/types_oai.py
+++ b/gpt_json/types_oai.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
Upon debugging some application stalls, I recognized that the `timeout` parameter supplied by OpenAI actually doesn't prevent against timeouts on the application level. Instead it's just popped from the kwargs and acts as a call loop if the model hasn't started yet. This seems to mainly be intended for custom models that need to boot.

```python
    @classmethod
    async def acreate(cls, *args, **kwargs):
        """
        Creates a new chat completion for the provided messages and parameters.

        See https://platform.openai.com/docs/api-reference/chat-completions/create
        for a list of valid parameters.
        """
        start = time.time()
        timeout = kwargs.pop("timeout", None)

        while True:
            try:
                return await super().acreate(*args, **kwargs)
            except TryAgain as e:
                if timeout is not None and time.time() > start + timeout:
                    raise

                util.log_info("Waiting for model to warm up", error=e)
```


Actual calls to the underlying aiohttp session just default to 600seconds once it's passed down into the arequest [builder](https://github.com/openai/openai-python/blob/fe3abd16b582ae784d8a73fd249bcdfebd5752c9/openai/api_requestor.py#L312).

This PR transitions the `GPTJSON(timeout=X)` parameter to act as most clients intend, namely serving as an upper bound for each request when it's sent to the server. To maintain backwards compatibility, however, we now default the timeout parameter to None which won't enforce a timeout on the server requests.