### PR TITLE
Introduce separate BaseModel for list responses

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11"]
+        python: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.10", "3.11"]
+        python: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ Detected sentiment: positive
 
 The `json_schema` is a special keyword that will be replaced with the schema definition at runtime. You should always include this in your payload to ensure the model knows how to format results. However, you can play around with _where_ to include this schema definition; in the system prompt, in the user prompt, at the beginning, or at the end.
 
-You can either typehint the model to return a BaseSchema back, or to provide a list of Multiple BaseSchema. Both of these work:
+You can either typehint the model to return a BaseSchema back, or to provide a list of multiple BaseSchema. Both of these work:
 
 ```python
+from gpt_json.gpt import GPTJSON, ListResponse
+
 gpt_json_single = GPTJSON[SentimentSchema](API_KEY)
-gpt_json_single = GPTJSON[list[SentimentSchema]](API_KEY)
+gpt_json_multiple = GPTJSON[ListResponse[SentimentSchema]](API_KEY)
 ```
 
 If you want to get more specific about how you expect the model to populate a field, add hints about the value through the "description" field. This helps the model understand what you're looking for, and will help it generate better results.

--- a/examples/truncation_example.py
+++ b/examples/truncation_example.py
@@ -1,11 +1,8 @@
 import asyncio
-import gzip
-import os
 import random
 from itertools import islice
 from os import getenv
 
-import requests
 from dotenv import load_dotenv
 from pydantic import BaseModel
 

--- a/gpt_json/generics.py
+++ b/gpt_json/generics.py
@@ -1,0 +1,64 @@
+from typing import Any, Type, TypeVar, get_args, get_origin
+
+from pydantic import BaseModel, Field, create_model
+
+
+def get_typevar_mapping(t: Any) -> dict[TypeVar, Any]:
+    origin = get_origin(t)
+    if not origin:
+        raise ValueError("The input is not an instantiated generic type")
+
+    base_parameters = getattr(origin, "__parameters__", [])
+    instantiated_parameters = get_args(t)
+
+    if len(base_parameters) != len(instantiated_parameters):
+        raise ValueError(
+            "The number of parameters in the base class doesn't match the instantiated class"
+        )
+
+    return dict(zip(base_parameters, instantiated_parameters))
+
+
+def resolve_type(type_: Any, typevar_mapping: dict) -> Any:
+    """Resolve a type based on the typevar_mapping."""
+    if type_ in typevar_mapping:
+        return typevar_mapping[type_]
+    elif get_origin(type_) is not None:
+        resolved_args = tuple(
+            resolve_type(arg, typevar_mapping) for arg in get_args(type_)
+        )
+        return get_origin(type_)[*resolved_args]
+    else:
+        return type_
+
+
+def resolve_generic_model(t: Any) -> Type[BaseModel]:
+    """
+    Pydantic doesn't natively have support for generic-defined models. This function
+    takes in a properly typehinted generic and recursively resolves it to the actual type.
+
+    """
+    if get_origin(t) is None:
+        # If it's not a generic, return it as is.
+        return t
+    else:
+        # Get a mapping from TypeVars to their actual types
+        typevar_mapping = get_typevar_mapping(t)
+
+        base_model = get_origin(t)
+
+        # Create a dict with all the fields from the original model
+        fields = {}
+        for name, type_ in base_model.__annotations__.items():
+            original_field = base_model.__fields__.get(name)
+            if original_field:
+                fields[name] = (type_, original_field.field_info)
+            else:
+                fields[name] = (type_, Field())
+
+        # Replace the fields that have a TypeVar with their resolved types
+        for name, (type_, field) in fields.items():
+            fields[name] = (resolve_type(type_, typevar_mapping), field)
+
+        # Use the Pydantic's create_model function to create a new model with the resolved fields
+        return create_model(base_model.__name__, **fields)  # type: ignore

--- a/gpt_json/gpt.py
+++ b/gpt_json/gpt.py
@@ -162,7 +162,7 @@ class GPTJSON(Generic[SchemaType]):
         max_response_tokens: int | None = None,
         format_variables: dict[str, Any] | None = None,
         truncation_options: TruncationOptions | None = None,
-    ) -> tuple[SchemaType | list[SchemaType], FixTransforms] | tuple[None, None]:
+    ) -> tuple[SchemaType, FixTransforms] | tuple[None, None]:
         """
         :param messages: List of GPTMessage objects to send to the API
         :param max_response_tokens: Maximum number of tokens allowed in the response

--- a/gpt_json/models.py
+++ b/gpt_json/models.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
 from enum import Enum, unique
-from typing import Callable, Iterator
+from typing import Callable
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -14,7 +14,6 @@ else:
 @unique
 class ResponseType(EnumSuper):
     DICTIONARY = "DICTIONARY"
-    LIST = "LIST"
 
 
 @unique

--- a/gpt_json/parsers.py
+++ b/gpt_json/parsers.py
@@ -12,11 +12,7 @@ def find_json_response(full_response, extract_type):
 
     """
     # Deal with fully included responses as well as truncated responses that only have one
-    if extract_type == ResponseType.LIST:
-        extracted_responses = list(
-            finditer(r"(\[[^\]]*$|\[.*\])", full_response, flags=DOTALL)
-        )
-    elif extract_type == ResponseType.DICTIONARY:
+    if extract_type == ResponseType.DICTIONARY:
         extracted_responses = list(
             finditer(r"({[^}]*$|{.*})", full_response, flags=DOTALL)
         )

--- a/gpt_json/prompts.py
+++ b/gpt_json/prompts.py
@@ -4,14 +4,14 @@ from typing import List, Type, get_args, get_origin
 from pydantic import BaseModel
 
 
-def generate_schema_prompt(schema: Type[BaseModel] | list[Type[BaseModel]]) -> str:
+def generate_schema_prompt(schema: Type[BaseModel]) -> str:
     """
     Converts the pydantic schema into a text representation that can be embedded
     into the prompt payload.
 
     """
 
-    def generate_payload(model):
+    def generate_payload(model: Type[BaseModel]):
         payload = []
         for key, value in model.__fields__.items():
             field_annotation = model.__annotations__[key]
@@ -19,7 +19,12 @@ def generate_schema_prompt(schema: Type[BaseModel] | list[Type[BaseModel]]) -> s
             annotation_arguments = get_args(field_annotation)
 
             if annotation_origin in {list, List}:
-                payload.append(f'"{key}": {annotation_arguments[0].__name__}[]')
+                if issubclass(annotation_arguments[0], BaseModel):
+                    payload.append(
+                        f'"{key}": {generate_payload(annotation_arguments[0])}[]'
+                    )
+                else:
+                    payload.append(f'"{key}": {annotation_arguments[0].__name__}[]')
             elif annotation_origin == UnionType:
                 payload.append(
                     f'"{key}": {" | ".join([arg.__name__.lower() for arg in annotation_arguments])}'
@@ -34,23 +39,4 @@ def generate_schema_prompt(schema: Type[BaseModel] | list[Type[BaseModel]]) -> s
         # pass custom variables
         return "{{\n" + ",\n".join(payload) + "\n}}"
 
-    origin = get_origin(schema)
-    args = get_args(schema)
-
-    if origin == list:
-        if len(args) > 1:
-            raise ValueError("Only one list schema is supported at this time")
-
-        return (
-            "["
-            + "\n".join(
-                [
-                    generate_payload(sub_schema)
-                    + ", // Repeat for as many objects as are relevant"
-                    for sub_schema in args
-                ]
-            )
-            + "]"
-        )
-    else:
-        return generate_payload(schema)
+    return generate_payload(schema)

--- a/gpt_json/tests/test_gpt.py
+++ b/gpt_json/tests/test_gpt.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, patch
 
 import openai
 import pytest
-from pydantic import BaseModel, Field
 from openai.error import Timeout as OpenAITimeout
+from pydantic import BaseModel, Field
 
-from gpt_json.gpt import GPTJSON
+from gpt_json.gpt import GPTJSON, ListResponse
 from gpt_json.models import FixTransforms, GPTMessage, GPTMessageRole, GPTModelVersion
 from gpt_json.tests.shared import MySchema, MySubSchema
 from gpt_json.transformations import JsonFixEnum
@@ -71,31 +71,35 @@ def test_cast_message_to_gpt_format(role_type: GPTMessageRole, expected: str):
             FixTransforms(),
         ),
         (
-            list[MySchema],
+            ListResponse[MySchema],
             """
             Your response is as follows:
-            [
-                {
-                    "text": "Test",
-                    "items": ["Item 1", "Item 2"],
-                    "numerical": 123,
-                    "sub_element": {
-                        "name": "Test"
-                    },
-                    "reason": true
-                }
-            ]
+            {
+                "items": [
+                    {
+                        "text": "Test",
+                        "items": ["Item 1", "Item 2"],
+                        "numerical": 123,
+                        "sub_element": {
+                            "name": "Test"
+                        },
+                        "reason": true
+                    }
+                ]
+            }
             Your response is above.
             """,
-            [
-                MySchema(
-                    text="Test",
-                    items=["Item 1", "Item 2"],
-                    numerical=123,
-                    sub_element=MySubSchema(name="Test"),
-                    reason=True,
-                )
-            ],
+            ListResponse(
+                items=[
+                    MySchema(
+                        text="Test",
+                        items=["Item 1", "Item 2"],
+                        numerical=123,
+                        sub_element=MySubSchema(name="Test"),
+                        reason=True,
+                    )
+                ]
+            ),
             FixTransforms(),
         ),
         (

--- a/gpt_json/tests/test_parsers.py
+++ b/gpt_json/tests/test_parsers.py
@@ -8,19 +8,19 @@ from gpt_json.parsers import find_json_response
     "input_string,expected,extract_type",
     [
         (
-            'This message is truncated: [{"key1": [123]',
-            '[{"key1": [123]',
-            ResponseType.LIST,
+            'This message is truncated: {"items":[{"key1": [123]',
+            '{"items":[{"key1": [123]',
+            ResponseType.DICTIONARY,
         ),
         (
-            'This message is truncated: [{"key1": [123',
-            '[{"key1": [123',
-            ResponseType.LIST,
+            'This message is truncated: {"items":[{"key1": [123',
+            '{"items":[{"key1": [123',
+            ResponseType.DICTIONARY,
         ),
         (
-            'This message is truncated: [{"key1": "abc"',
-            '[{"key1": "abc"',
-            ResponseType.LIST,
+            'This message is truncated: {"items":[{"key1": "abc"',
+            '{"items":[{"key1": "abc"',
+            ResponseType.DICTIONARY,
         ),
         (
             'This message is truncated: {"key": "value", "list": [1, 2, 3',

--- a/gpt_json/tests/test_prompts.py
+++ b/gpt_json/tests/test_prompts.py
@@ -2,6 +2,8 @@ from re import sub
 
 import pytest
 
+from gpt_json.generics import resolve_generic_model
+from gpt_json.gpt import ListResponse
 from gpt_json.prompts import generate_schema_prompt
 from gpt_json.tests.shared import MySchema
 
@@ -28,24 +30,24 @@ def strip_whitespace(input_string: str):
             """,
         ),
         (
-            list[MySchema],
+            ListResponse[MySchema],
             """
-            [
             {{
-            "text": str,
-            "items": str[],
-            "numerical": int | float,
-            "sub_element": {{
-                "name": str
-            }},
-            "reason": bool // Explanation
-            }}, // Repeat for as many objects as are relevant
-            ]
+            "items": {{
+                "text": str,
+                "items": str[],
+                "numerical": int | float,
+                "sub_element": {{
+                    "name": str
+                }},
+                "reason": bool // Explanation            
+            }}[] // Repeat for as many objects as are relevant
+            }}
             """,
         ),
     ],
 )
 def test_generate_schema_prompt(schema_definition, expected: str):
     assert strip_whitespace(
-        generate_schema_prompt(schema_definition)
+        generate_schema_prompt(resolve_generic_model(schema_definition))
     ) == strip_whitespace(expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "gpt_json"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 tiktoken = "^0.3.3"
 openai = "^0.27.6"
 pydantic = "^1.10.7"


### PR DESCRIPTION
Originally defined in: https://github.com/piercefreeman/gpt-json/issues/32

mypy couldn't properly typehint our run() responses when list values were requested as the output format, because our main SchemaType variable is pinned to a BaseModel `base` value. Lists would work at runtime but not during typehinting, which made it harder to debug client code.

Here we standardize the generic API so everything passed in is a BaseModel. We also add a small helper function `ListResponse` that allows clients to easily request a list as output. Because this ListResponse is typehinted generically, we also add a series of helper functions that allow us to more easily deal with generics in pydantic.