### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/gpt_json/gpt.py
+++ b/gpt_json/gpt.py
@@ -17,6 +17,7 @@ from typing import (
 
 import backoff
 import openai
+from litellm import completion, acompletion
 from openai.error import APIConnectionError, RateLimitError
 from openai.error import Timeout as OpenAITimeout
 from pydantic import BaseModel, Field
@@ -95,7 +96,7 @@ class GPTJSON(Generic[SchemaType]):
     ):
         """
         :param api_key: OpenAI API key, if `OPENAI_API_KEY` environment variable is not set
-        :param model: GPTModelVersion or string model name
+        :param model: GPTModelVersion or string model name, see supported models here: https://litellm.readthedocs.io/en/latest/supported/
         :param auto_trim: If True, automatically trim messages to fit within the model's token limit
         :param auto_trim_response_overhead: If auto_trim is True, will leave at least `auto_trim_response_overhead` space
             for the output payload. For GPT, initial prompt + response <= allowed tokens.
@@ -340,7 +341,7 @@ class GPTJSON(Generic[SchemaType]):
         if max_response_tokens:
             optional_parameters["max_tokens"] = max_response_tokens
 
-        execute_prediction = openai.ChatCompletion.acreate(
+        execute_prediction = acompletion(
             model=self.model,
             messages=[self.message_to_dict(message) for message in messages],
             temperature=self.temperature,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "gpt_json"}]
 python = "^3.11"
 tiktoken = "^0.3.3"
 openai = "^0.27.6"
+litellm = "^0.1.232"
 pydantic = "^1.10.7"
 backoff = "^2.2.1"
 


### PR DESCRIPTION
Addresses https://github.com/piercefreeman/gpt-json/issues/29 

I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic, Replicate API Endpoints

This PR adds support for models from all the above mentioned providers 

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# async openai
response = acompletion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```