### PR TITLE
Fix hanging brackets & literal schemas

### DIFF
--- a/gpt_json/models.py
+++ b/gpt_json/models.py
@@ -48,6 +48,11 @@ class JsonFixEnum(EnumSuper):
     UNCLOSED_VALUE = "unclosed_value"
     MISSING_VALUE = "missing_value"
 
+    # Drop any additional JSON tags that occur after the main payload
+    # has been processed; this most often happens when the models spit back
+    # double close brackets like ]] or }}
+    DROP_TRAILING_JSON = "drop_trailing_json"
+
 
 @dataclass
 class FixTransforms:

--- a/gpt_json/prompts.py
+++ b/gpt_json/prompts.py
@@ -1,5 +1,5 @@
 from types import UnionType
-from typing import List, Type, get_args, get_origin
+from typing import List, Literal, Type, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -31,6 +31,9 @@ def generate_schema_prompt(schema: Type[BaseModel]) -> str:
                 payload.append(
                     f'"{key}": {" | ".join([arg.__name__.lower() for arg in annotation_arguments])}'
                 )
+            elif annotation_origin == Literal:
+                allowed_values = [f'"{arg}"' for arg in annotation_arguments]
+                payload.append(f'"{key}": {" | ".join(allowed_values)}')
             elif issubclass(field_annotation, BaseModel):
                 payload.append(f'"{key}": {generate_payload(field_annotation)}')
             else:

--- a/gpt_json/tests/shared.py
+++ b/gpt_json/tests/shared.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -13,6 +14,12 @@ class MySchema(BaseModel):
     numerical: int | float
     sub_element: MySubSchema
     reason: bool = Field(description="Explanation")
+
+
+class LiteralSchema(BaseModel):
+    work_format: Literal["REMOTE", "OFFICE", "ANY"] = Field(
+        default="ANY", description="One of the given values"
+    )
 
 
 class UnitType(Enum):

--- a/gpt_json/tests/test_parsers.py
+++ b/gpt_json/tests/test_parsers.py
@@ -32,6 +32,11 @@ from gpt_json.parsers import find_json_response
             '{"text": "Test", "numerical": 123, "reason": true, "sub_element": { "name": "Test" }, "items": ["Item 1", "Item 2',
             ResponseType.DICTIONARY,
         ),
+        (
+            'This message has an additional closing bracket: {"text": "Test"}}',
+            '{"text": "Test"}}',
+            ResponseType.DICTIONARY,
+        ),
     ],
 )
 def test_find_json_response(input_string, expected, extract_type):

--- a/gpt_json/tests/test_prompts.py
+++ b/gpt_json/tests/test_prompts.py
@@ -5,7 +5,7 @@ import pytest
 from gpt_json.generics import resolve_generic_model
 from gpt_json.gpt import ListResponse
 from gpt_json.prompts import generate_schema_prompt
-from gpt_json.tests.shared import MySchema
+from gpt_json.tests.shared import LiteralSchema, MySchema
 
 
 def strip_whitespace(input_string: str):
@@ -42,6 +42,14 @@ def strip_whitespace(input_string: str):
                 }},
                 "reason": bool // Explanation            
             }}[] // Repeat for as many objects as are relevant
+            }}
+            """,
+        ),
+        (
+            LiteralSchema,
+            """
+            {{
+            "work_format": "REMOTE" | "OFFICE" | "ANY" // One of the given values
             }}
             """,
         ),

--- a/gpt_json/tests/test_transformations.py
+++ b/gpt_json/tests/test_transformations.py
@@ -114,6 +114,13 @@ def test_is_truncated(input_string: str, expected: bool):
             },
             JsonFixEnum.UNCLOSED_VALUE,
         ),
+        (
+            '{"text": "Test"}}',
+            {
+                "text": "Test",
+            },
+            JsonFixEnum.DROP_TRAILING_JSON,
+        ),
     ],
 )
 def test_fix_truncated_json(broken_string, expected, expected_fix_reason):

--- a/gpt_json/transformations.py
+++ b/gpt_json/transformations.py
@@ -20,7 +20,6 @@ def build_stack(json_str):
             # closing a nested
             elif char in "}]":
                 if len(stack) == 0:
-                    print("will break")
                     break
                 stack.pop()
                 last_seen_comma_or_colon = None
@@ -108,7 +107,6 @@ def fix_truncated_json(json_str) -> tuple[str, JsonFixEnum | None]:
         close_stack = ["]" if char == "[" else "}" for char in stack]
         fixed_str += "".join(close_stack[::-1])
 
-    print("FIXED", fixed_str)
     # if the fixed string is valid JSON, return it
     fix = JsonFixEnum.UNCLOSED_OBJECT
     if open_quotes:


### PR DESCRIPTION
The previous json-extraction logic worked fine if values were truncated, but building the stack failed if there were closing brackets that didn't align with opening ones. This was observed in the wild in some responses coming back from GPT-3.5 more often than GPT-4.

```json
{
  "text": "Text"
}}
```

```bash
  File "/Users/piercefreeman/Library/Caches/pypoetry/virtualenvs/popcorn-data-cZ187J5_-py3.11/lib/python3.11/site-packages/gpt_json/parsers.py", line 33, in find_json_response
    if is_truncated(extracted_response.group(0)):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/piercefreeman/Library/Caches/pypoetry/virtualenvs/popcorn-data-cZ187J5_-py3.11/lib/python3.11/site-packages/gpt_json/transformations.py", line 62, in is_truncated
    stack, _, _, _ = build_stack(json_str)
                     ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/piercefreeman/Library/Caches/pypoetry/virtualenvs/popcorn-data-cZ187J5_-py3.11/lib/python3.11/site-packages/gpt_json/transformations.py", line 21, in build_stack
    stack.pop()
IndexError: pop from empty list
```

We also extend our schema construction to support literals in the pydantic definition. This lets users specify fixed values into the model without defining an additional enum. Reported in https://github.com/piercefreeman/gpt-json/issues/39.

```python
class LiteralSchema(BaseModel):
    work_format: Literal["REMOTE", "OFFICE", "ANY"] = Field(
        default="ANY", description="One of the given values"
    )
```