### PR TITLE
Unit tests failing due to model deprecated_date

### DIFF
--- a/gpt_json/tests/test_gpt.py
+++ b/gpt_json/tests/test_gpt.py
@@ -164,7 +164,7 @@ async def test_create(
     parsed: BaseModel,
     expected_transformations: FixTransforms,
 ):
-    model_version = GPTModelVersion.GPT_3_5
+    model_version = GPTModelVersion.GPT_4
     messages = [
         GPTMessage(
             role=GPTMessageRole.USER,
@@ -209,7 +209,7 @@ async def test_create(
 async def test_create_with_function_calls(
     httpx_mock: HTTPXMock,
 ):
-    model_version = GPTModelVersion.GPT_3_5
+    model_version = GPTModelVersion.GPT_4
     messages = [
         GPTMessage(
             role=GPTMessageRole.USER,

--- a/gpt_json/tests/test_streaming.py
+++ b/gpt_json/tests/test_streaming.py
@@ -81,7 +81,7 @@ async def test_gpt_stream(
     expected_stream_data,
     should_support,
 ):
-    model_version = GPTModelVersion.GPT_3_5
+    model_version = GPTModelVersion.GPT_4
     messages = [
         GPTMessage(
             role=GPTMessageRole.USER,


### PR DESCRIPTION
GPT 3.5 in the code is deprecated_date is June 13 2024.
Moved unit tests to use GPT_4